### PR TITLE
feat: gen-pass support --no-special (no special characters)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,8 +23,11 @@ pub enum Command {
     /// Generate random password
     GenPass {
         /// The target folder
-        #[structopt(short, long, default_value = "16")]
+        #[structopt(short, long, default_value = "32")]
         length: u8,
+        /// No special characters
+        #[structopt(short, long)]
+        no_special: bool,
         /// The username, using to create md5 hash
         #[structopt(short, long)]
         username: Option<String>,

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -28,19 +28,30 @@ pub fn gen(target: &PathBuf) {
 }
 
 /// Generating password with given length
-pub fn gen_password(length: u8, username: Option<String>, password: Option<String>) {
+pub fn gen_password(
+    length: u8,
+    no_special: bool,
+    username: Option<String>,
+    password: Option<String>,
+) {
     // If not password is given, generate random password
     let password = match password {
         Some(p) => p,
         None => {
-            const CHARS: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
-                                   abcdefghijklmnopqrstuvwxyz\
-                                   0123456789)(*&^%$#@!~";
+            let chars: &[u8] = if no_special {
+                b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+                  abcdefghijklmnopqrstuvwxyz\
+                  0123456789"
+            } else {
+                b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+                  abcdefghijklmnopqrstuvwxyz\
+                  0123456789)(*&^%#!~"
+            };
             let mut rng = rand::thread_rng();
             let password: String = (0..length)
                 .map(|_| {
-                    let idx = rng.gen_range(0..CHARS.len());
-                    CHARS[idx] as char
+                    let idx = rng.gen_range(0..chars.len());
+                    chars[idx] as char
                 })
                 .collect();
 
@@ -82,9 +93,12 @@ mod tests {
     // Test gen_password
     #[test]
     fn test_gen_password() {
-        gen_password(10, None, None);
-        gen_password(10, Some("test".to_string()), None);
-        gen_password(10, Some("test".to_string()), Some("test".to_string()));
+        gen_password(10, true, None, None);
+        gen_password(10, true, Some("test".to_string()), None);
+        gen_password(10, true, Some("test".to_string()), Some("test".to_string()));
+        gen_password(10, false, None, None);
+        gen_password(10, false, Some("test".to_string()), None);
+        gen_password(10, false, Some("test".to_string()), Some("test".to_string()));
     }
 
     // Test gen_md5_password

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,10 +24,11 @@ fn main() -> Result<()> {
 
         Command::GenPass {
             length,
+            no_special,
             username,
             password,
         } => {
-            gen::gen_password(length, username, password);
+            gen::gen_password(length, no_special, username, password);
         }
 
         Command::Validate { file } => {


### PR DESCRIPTION
Support `-n --no-special` no special characters for gen-pass, generated password with 32 characters by default.

```diff
grant-gen-pass 0.0.1-beta.3
Generate random password

USAGE:
    grant gen-pass [FLAGS] [OPTIONS]

FLAGS:
     -h, --help          Prints help information
+    -n, --no-special    No special characters
      -V, --version      Prints version information

OPTIONS:
    -l, --length <length>        The target folder [default: 32]
    -p, --password <password>    The password, using to create md5 hash
    -u, --username <username>    The username, using to create md5 hash
```

Example: 

```bash
$ grant gen-pass
# Generated password: XO)Dt0VhggdqOS4Z8GVi5!bxmqZKLaJs
```

```bash
$ grant gen-pass -n
# Generated password: t48psHFJwFjPGyuJPE2jnoeNpx80j1eA
```