### PR TITLE
fix: prevent panic when files have no extension

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -45,9 +45,10 @@ pub fn apply_all(target: &Path, dryrun: bool) -> Result<()> {
         let entry = entry?;
         let path = entry.path();
         if path.is_file() {
-            let ext = path.extension().unwrap();
-            if ext == "yaml" || ext == "yml" {
-                config_files.push(path);
+            if let Some(ext) = path.extension() {
+                if ext == "yaml" || ext == "yml" {
+                    config_files.push(path);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
🚨 **CRITICAL CRASH FIX** 🚨

Fixes panic vulnerability when processing directories containing files without extensions.

### Issue Fixed
**Location**: `src/apply.rs:48`
**Problem**: `path.extension().unwrap()` panics when file has no extension
**Impact**: Application crashes when scanning directories with extension-less files

### Changes Made
- ✅ Replace `.unwrap()` with safe `if let Some(ext)` pattern
- ✅ Files without extensions are now safely ignored
- ✅ Maintains existing functionality for .yaml and .yml files
- ✅ No behavior change for valid config files

### Risk Mitigation
**Before**: Files like `Dockerfile`, `README`, etc. would crash the application
**After**: Extension-less files are safely skipped without affecting operation

### Test Plan
- [x] Code compiles without errors  
- [x] Existing functionality preserved for .yaml/.yml files
- [x] No crashes when processing directories with mixed file types

**Priority**: Critical fix preventing application crashes in common scenarios