### PR TITLE
fix: replace role lookup panic with proper error handling

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -175,7 +175,9 @@ fn create_or_update_privileges(
         // If privileges on config are not in db, add them
         // If privileges on db are not in config, remove them
         for role_name in user.roles.iter() {
-            let role = config.roles.iter().find(|&r| r.find(role_name)).unwrap();
+            let role = config.roles.iter()
+                .find(|&r| r.find(role_name))
+                .ok_or_else(|| anyhow!("Role '{}' not found for user '{}'", role_name, user.name))?;
 
             // TODO: revoke if privileges on db are not in configuration
 


### PR DESCRIPTION
## Summary
🚨 **MAJOR CRASH FIX** 🚨

Replaces panic-prone role lookup with descriptive error handling when roles are not found.

### Issue Fixed
**Location**: `src/apply.rs:178`
**Problem**: `.unwrap()` on role lookup panics when role doesn't exist
**Impact**: Application crashes when user configuration references non-existent roles

### Changes Made
- ✅ Replace `.unwrap()` with safe `.ok_or_else()` pattern
- ✅ Provide descriptive error: `"Role 'role_name' not found for user 'username'"`
- ✅ Prevents application crash on configuration errors
- ✅ Maintains existing functionality for valid role references

### Error Handling Improvement
**Before**: Silent crash with no helpful information
**After**: Clear error message identifying missing role and affected user

### Test Plan
- [x] Code compiles without errors
- [x] Valid role lookups continue to work normally  
- [x] Invalid role names now produce helpful errors instead of crashes
- [x] Error messages identify both the missing role and the user

**Priority**: Major fix preventing crashes on common configuration errors