### PR TITLE
fix: prevent panic on files with invalid UTF-8 names or missing names

### DIFF
--- a/src/validate.rs
+++ b/src/validate.rs
@@ -23,12 +23,13 @@ pub fn validate_target(target: &Path) -> Result<()> {
         for entry in WalkDir::new(target) {
             let entry = entry?;
             if entry.path().is_file() {
-                let file_name = entry.path().file_name().unwrap();
-                if file_name.to_str().unwrap().ends_with(".yaml")
-                    || file_name.to_str().unwrap().ends_with(".yml")
-                {
-                    let path = entry.path().to_path_buf();
-                    files.push(path);
+                if let Some(file_name) = entry.path().file_name() {
+                    if let Some(name_str) = file_name.to_str() {
+                        if name_str.ends_with(".yaml") || name_str.ends_with(".yml") {
+                            let path = entry.path().to_path_buf();
+                            files.push(path);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
🚨 **MAJOR CRASH FIX** 🚨

Prevents panic when processing files with invalid UTF-8 names or missing file names.

### Issue Fixed
**Location**: `src/validate.rs:26-28`
**Problem**: Multiple `.unwrap()` calls on file name processing cause crashes
**Impact**: Application panics when encountering files with invalid UTF-8 names

### Changes Made
- ✅ Replace `.unwrap()` on `file_name()` with safe `if let Some()` pattern
- ✅ Replace double `.unwrap()` on `to_str()` with safe Option handling
- ✅ Files with invalid UTF-8 names are now safely ignored
- ✅ Files without names are safely handled without crashing
- ✅ Maintains existing functionality for valid .yaml and .yml files

### Error Handling Improvement
**Before**: Immediate crash on invalid UTF-8 filenames or missing file names
**After**: Invalid files are safely skipped, processing continues normally

### Test Plan
- [x] Code compiles without errors
- [x] Valid .yaml/.yml files continue to be processed normally
- [x] Invalid UTF-8 filenames no longer cause crashes
- [x] Directory scanning is more robust and reliable

**Priority**: Major fix preventing crashes when processing diverse file systems