### PR TITLE
fix: add proper error context for database query operations

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -191,10 +191,12 @@ impl DbConnection {
 
         // TODO: Get the password from database, currently it only returns *****
         let sql = "SELECT usename, usecreatedb, usesuper, passwd FROM pg_user";
-        let stmt = self.client.prepare(sql).unwrap();
+        let stmt = self.client.prepare(sql)
+            .map_err(|e| anyhow!("Failed to prepare query for users: {}", e))?;
 
         debug!("executing: {}", sql);
-        let rows = self.client.query(&stmt, &[]).unwrap();
+        let rows = self.client.query(&stmt, &[])
+            .map_err(|e| anyhow!("Failed to query users from pg_user: {}", e))?;
 
         for row in rows {
             match (row.get(0), row.get(1), row.get(2), row.get(3)) {
@@ -242,10 +244,12 @@ impl DbConnection {
             FROM db CROSS JOIN users u;
         "#;
 
-        let stmt = self.client.prepare(sql).unwrap();
+        let stmt = self.client.prepare(sql)
+            .map_err(|e| anyhow!("Failed to prepare query for database privileges: {}", e))?;
 
         debug!("executing: {}", sql);
-        let rows = self.client.query(&stmt, &[])?;
+        let rows = self.client.query(&stmt, &[])
+            .map_err(|e| anyhow!("Failed to query database privileges: {}", e))?;
         for row in rows {
             let name: &str = row.get(0);
             let database_name: &str = row.get(1);
@@ -281,10 +285,12 @@ impl DbConnection {
               AND s.schemaname != 'information_schema';
         ";
 
-        let stmt = self.client.prepare(sql).unwrap();
+        let stmt = self.client.prepare(sql)
+            .map_err(|e| anyhow!("Failed to prepare query for schema privileges: {}", e))?;
 
         debug!("executing: {}", sql);
-        let rows = self.client.query(&stmt, &[])?;
+        let rows = self.client.query(&stmt, &[])
+            .map_err(|e| anyhow!("Failed to query schema privileges: {}", e))?;
         let mut roles = vec![];
         for row in rows {
             let name = row.get(0);
@@ -327,10 +333,12 @@ impl DbConnection {
                 AND t.schemaname != 'information_schema';
         ";
 
-        let stmt = self.client.prepare(sql).unwrap();
+        let stmt = self.client.prepare(sql)
+            .map_err(|e| anyhow!("Failed to prepare query for table privileges: {}", e))?;
 
         debug!("executing: {}", sql);
-        let rows = self.client.query(&stmt, &[])?;
+        let rows = self.client.query(&stmt, &[])
+            .map_err(|e| anyhow!("Failed to query table privileges: {}", e))?;
         for row in rows {
             let name = row.get(0);
             let schema_name = row.get(1);


### PR DESCRIPTION
## Summary
🚨 **HIGH SEVERITY FIX** 🚨

Adds descriptive error context to all database query operations, replacing panic-prone `.unwrap()` calls.

### Issue Fixed
**Locations**: 
- `src/connection.rs:194, 197` - get_users()
- `src/connection.rs:247, 250` - get_user_database_privileges()
- `src/connection.rs:288, 291` - get_user_schema_privileges()
- `src/connection.rs:336, 339` - get_user_table_privileges()

**Problem**: `.unwrap()` on database operations hides all error context
**Impact**: When database queries fail, developers get no diagnostic information

### Changes Made
- ✅ Replace all `.unwrap()` with `.map_err()` providing clear error messages
- ✅ Add specific context for each operation type (users, privileges, schemas, tables)
- ✅ Distinguish between prepare failures and query execution failures
- ✅ All tests pass with improved error handling

### Error Handling Improvement
**Before**: Panic with no context when database operations fail
**After**: Descriptive errors like:
- `"Failed to prepare query for users: permission denied"`
- `"Failed to query table privileges: relation does not exist"`

### Test Plan
- [x] Code compiles without errors
- [x] All connection tests pass
- [x] Existing functionality preserved
- [x] Error messages provide actionable diagnostic information

**Priority**: High severity fix for production debugging and reliability

## Summary by Sourcery

Replace panic-prone unwraps in database query methods with proper error handling, providing context-specific error messages for both prepare and execution failures across user, database, schema, and table privilege operations.

Bug Fixes:
- Avoid panics by replacing unwrap() calls in user, database, schema, and table privilege queries with map_err error propagation.

Enhancements:
- Add descriptive error contexts distinguishing prepare failures from query execution failures for all database operations.