### PR TITLE
fix: replace panic with proper error handling in gen() function

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,10 @@ fn main() -> Result<()> {
 
     match cli::parse().cmd {
         Command::Gen { target } => {
-            gen::gen(&target);
+            if let Err(e) = gen::gen(&target) {
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
         }
 
         Command::GenPass {


### PR DESCRIPTION
## Summary
🚨 **MEDIUM SEVERITY FIX** 🚨

Replaces explicit panics with proper error handling in the gen() function for better error reporting.

### Issue Fixed
**Locations**: 
- `src/gen.rs:19` - Directory creation panic
- `src/gen.rs:28` - File write panic

**Problem**: Explicit `panic!()` calls on filesystem errors
**Impact**: Application crashes instead of providing clean error messages

### Changes Made
- ✅ Change `gen()` signature to return `Result<()>`
- ✅ Replace `panic!()` on directory creation with `.context()`
- ✅ Replace `panic!()` on file write with `.context()`
- ✅ Add error handling for YAML serialization
- ✅ Update `main.rs` to handle Result and exit cleanly with error message

### Error Handling Improvement
**Before**: Panic with raw error message: `"failed to generate /path"`
**After**: Clean error exit with context: `"Error: Failed to create directory /path: permission denied"`

### Test Plan
- [x] Code compiles without errors
- [x] All gen module tests pass
- [x] CLI tests verify correct behavior
- [x] Errors propagate cleanly without panicking

**Priority**: Medium severity fix for better user experience and error diagnostics

## Summary by Sourcery

Replace panics in gen() with proper error handling and update main to handle errors gracefully

Bug Fixes:
- Replace panic on directory creation and file write in gen() with Result-based error propagation using context
- Add error handling for YAML serialization failures

Enhancements:
- Change gen() signature to return Result<()> instead of panicking
- Update main.rs to handle gen() errors, print error and exit cleanly